### PR TITLE
Dependabot group version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,20 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "monthly"
+    groups:
+      github-actions:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
       interval: "monthly"
+    groups:
+      npm:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
This pull request includes modifications to the `.github/dependabot.yml` file. The changes introduce two new groups, `github-actions` and `npm`, to the `updates:` section. These groups are configured to apply to version updates and allow only minor and patch updates.

Most important changes:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R12-R28): Added `github-actions` and `npm` groups to the `updates:` section. Both groups are set to apply to version updates and allow only minor and patch updates.