### PR TITLE
fixing the CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,9 @@ jobs:
         npm run test
 
     # validate if the dist folder has no changes that are not commited
-    - name: 'Check for dist folder changes'
+    - name: Check for uncommitted changes
       run: |
-        git diff --exit-code --name-only ${{ github.sha }} ${{ github.sha }}^
-        if [ $? -eq 1 ]; then
-          echo "dist folder has changes that are not commited"
+        if [[ -n $(git status --porcelain) ]]; then
+          echo "dist folder has changes that are not committed"
           exit 1
         fi


### PR DESCRIPTION
This pull request includes a modification to the Continuous Integration (CI) workflow in the `.github/workflows/ci.yml` file. The change improves the validation step that checks for uncommitted changes in the `dist` folder. 

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL32-R35): The name of the validation step has been updated from 'Check for dist folder changes' to 'Check for uncommitted changes'. The command used to check for changes has been simplified to use `git status --porcelain`, which provides a cleaner and more direct way to identify uncommitted changes. The error message has also been corrected for a spelling mistake.